### PR TITLE
tools: update clang/gcc support tables

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -3,12 +3,12 @@
 | MSVC 2022     |  ✅      |  17.6         |
 | Clang         |   Partial      |         17       |
 | Apple Clang   |  ❌            |  ❌            |
-| GCC           |  ❌            |         ❌       |
+| GCC           |  Partial       |         14       |
 
 | Tool/Compiler | C++23 `import std` | Version Support |
 |---------------|---------------------|-----------------|
 | MSVC 2022     |  Partial            |  17.10          |
-| Clang         |  ❌            |  ❌              |
+| Clang         |  Partial            |  18             |
 | Apple Clang   |  ❌                 |  ❌              |
 | GCC           |  ❌                 |     ❌            |
 


### PR DESCRIPTION
GCC 14 will contain P1689 support. Clang 18 supports `import std` via `libc++`.

---
Of course, even MSVC's C++20 module support should probably be "Partial" given that there are likely many bugs yet to be discovered.