### PR TITLE
update status for async_simple

### DIFF
--- a/data/progress.yml
+++ b/data/progress.yml
@@ -641,13 +641,14 @@ ports:
   status: ❔
   tracking_issue: ''
   version: 4.1.0
-- current_min_cpp_version: Unknown
+- current_min_cpp_version: 20
   help_wanted: ❔
   homepage: https://github.com/alibaba/async_simple
-  modules_support_date: 0
+  import_statement: async_simple
+  modules_support_date: 1687167198
   name: async-simple
   revision_count: 2
-  status: ❔
+  status: ✅
   tracking_issue: ''
   version: '1.3'
 - current_min_cpp_version: Unknown

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -30,6 +30,11 @@ ports:
   modules_support_date: 1691048988
   status: ✅
   current_min_cpp_version: 20
+- name: async-simple
+  import_statement: async_simple
+  modules_support_date: 1687167198
+  status: ✅
+  current_min_cpp_version: 20
 - name: protobuf
   tracking_issue: "https://github.com/protocolbuffers/protobuf/issues/14109"
   status: ❌


### PR DESCRIPTION
I just realized we have `async_simple` in vcpkg (with a name 'async-simple' so I failed to get it).

I still hope we can have a line for `seastar`. Is it possible to a have an item in `progress_overwrite.yml` but not in `raw_progress.yml`?