### PR TITLE
Allow to add new item in progress_overwrite.yml and add seastar

### DIFF
--- a/data/progress.yml
+++ b/data/progress.yml
@@ -21839,3 +21839,12 @@ ports:
   status: ❔
   tracking_issue: ''
   version: 0.13.73
+- current_min_cpp_version: Unknown
+  help_wanted: ❔
+  homepage: https://github.com/scylladb/seastar/tree/master
+  import_statement: ''
+  modules_support_date: 1679636937
+  name: seastar
+  status: ✅
+  tracking_issue: ''
+  version: ''

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -33,6 +33,10 @@ ports:
 - name: protobuf
   tracking_issue: "https://github.com/protocolbuffers/protobuf/issues/14109"
   status: ❌
+- name: seastar
+  homepage: https://github.com/scylladb/seastar/tree/master
+  modules_support_date: 1679636937
+  status: ✅
 - name: catch2
   tracking_issue: "https://github.com/catchorg/Catch2/issues/2575"
   status: ❌

--- a/generate_vcpkg_usage_stats.py
+++ b/generate_vcpkg_usage_stats.py
@@ -79,6 +79,23 @@ def load_and_merge_yaml(file1, file2, output_file):
                 if key in overwrite_dict[item['name']]:
                     item[key] = overwrite_dict[item['name']][key]
         merged_ports.append(item)
+
+    # Add project not listed in vcpkg
+    ## Create a dictionary from the merged ports data for easy access
+    merged_set = {item['name'] for item in merged_ports}
+    for name,item in overwrite_dict.items():
+        if name not in merged_set:
+            merged_ports.append({
+                "name": name,
+                "current_min_cpp_version": item.get("current_min_cpp_version", "Unknown"),
+                "help_wanted": item.get("help_wanted", "❔"),
+                "homepage": item.get("homepage", ""),
+                "modules_support_date": item.get("modules_support_date", "0"),
+                "status": item.get("status", "?"),
+                "tracking_issue": item.get("tracking_issue", ""),
+                "version": item.get("version", ""),
+                "import_statement": item.get("import_statement", "")
+            })
     
     # Reconstruct the merged data with header
     merged_data = {


### PR DESCRIPTION
See https://github.com/kelteseth/arewemodulesyet/issues/10 and  https://github.com/kelteseth/arewemodulesyet/pull/16 for some background. It looks like we can't make it by simply editing the `progress_overwrite.yml` but have to edit the python scripts.

Tested locally.