### PR TITLE
update minimal C++ version of Seastar

### DIFF
--- a/data/progress.yml
+++ b/data/progress.yml
@@ -21865,7 +21865,7 @@ ports:
   status: ❔
   tracking_issue: ''
   version: 0.13.73
-- current_min_cpp_version: 17
+- current_min_cpp_version: 20
   help_wanted: ❔
   homepage: https://github.com/scylladb/seastar/tree/master
   import_statement: seastar

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -135,7 +135,7 @@ ports:
   modules_support_date: 2023/3/24
   status: ✅
   import_statement: seastar
-  current_min_cpp_version: 17
+  current_min_cpp_version: 20
 - name: cpp-lazy
   homepage: https://github.com/MarcDirven/cpp-lazy
   modules_support_date: 2024/4/9


### PR DESCRIPTION
Seastar now requires C++20, so replace "17" with "20" in Seastar's section.