### PR TITLE
Updated status for bshoshany-thread-pool

### DIFF
--- a/data/progress.yml
+++ b/data/progress.yml
@@ -3084,15 +3084,16 @@ ports:
   status: ❔
   tracking_issue: ''
   version: 1.12.2
-- current_min_cpp_version: Unknown
-  help_wanted: ❔
+- current_min_cpp_version: 17
+  help_wanted: ❌
   homepage: https://github.com/bshoshany/thread-pool
-  modules_support_date: ''
+  import_statement: BS.thread_pool
+  modules_support_date: 2024/12/19
   name: bshoshany-thread-pool
   revision_count: 11
-  status: ❔
+  status: ✅
   tracking_issue: ''
-  version: 4.1.0
+  version: 5.0.0
 - current_min_cpp_version: Unknown
   help_wanted: ❔
   homepage: https://github.com/ArkNX/bsio

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -157,6 +157,12 @@ ports:
   modules_support_date: 2024/12/19
   status: ✅
   tracking_issue: "https://github.com/boostorg/regex/pull/174"
+- name: bshoshany-thread-pool
+  import_statement: BS.thread_pool
+  modules_support_date: 2024/12/19
+  status: ✅
+  help_wanted: ❌
+  current_min_cpp_version: 17
 
 ###############################################################################  
 # Libraries that are not part of vcpkg


### PR DESCRIPTION
This library supports C++20 modules (as well as importing the C++23 Standard Library as a module) starting from v5.0.0. Note that v5.0.0 is not on vcpkg yet (usually it takes them some time to approve the PR), but it is available on [the GitHub repository](https://github.com/bshoshany/thread-pool).