### PR TITLE
Update libraries with modules in progress

### DIFF
--- a/content/examples.md
+++ b/content/examples.md
@@ -17,3 +17,4 @@ about how to develop with modules natively.
 - [technical-machine](https://github.com/davidstone/technical-machine)
 - [atr](https://github.com/kaimfrai/atr/tree/main)
 - [async_simple's modules branch](https://github.com/alibaba/async_simple/tree/CXX20Modules)
+- [openJuice](https://github.com/mikomikotaishi/openJuice)

--- a/data/progress.yml
+++ b/data/progress.yml
@@ -2456,7 +2456,7 @@ ports:
 - current_min_cpp_version: Unknown
   help_wanted: ❔
   homepage: https://github.com/boostorg/pfr
-  import_statement: Boost.PFR
+  import_statement: boost.pfr
   modules_support_date: 2024/08/01
   name: boost-pfr
   revision_count: 12

--- a/data/progress.yml
+++ b/data/progress.yml
@@ -6464,8 +6464,8 @@ ports:
   modules_support_date: ''
   name: ftxui
   revision_count: 9
-  status: ❔
-  tracking_issue: ''
+  status: ⚙️
+  tracking_issue: https://github.com/ArthurSonzogni/FTXUI/pull/1015
   version: Unknown
 - current_min_cpp_version: Unknown
   help_wanted: ❔
@@ -13808,11 +13808,10 @@ ports:
 - current_min_cpp_version: Unknown
   help_wanted: ❌
   homepage: https://github.com/nlohmann/json
-  import_statement: json
-  modules_support_date: 2025/05/01
+  modules_support_date: 
   name: nlohmann-json
   revision_count: 25
-  status: ✅
+  status: ⚙️
   tracking_issue: https://github.com/nlohmann/json/pull/4764
   version: Unknown
 - current_min_cpp_version: Unknown
@@ -14553,6 +14552,16 @@ ports:
   status: ❔
   tracking_issue: ''
   version: 2.5.2
+- current_min_cpp_version: Unknown
+  help_wanted: ❔
+  homepage: https://github.com/mikomikotaishi/openJuice
+  import_statement: ''
+  module_native: ✅
+  modules_support_date: 2024/8/7
+  name: openJuice
+  status: ✅
+  tracking_issue: ''
+  version: ''
 - current_min_cpp_version: Unknown
   help_wanted: ❔
   homepage: https://www.openldap.org/software/
@@ -15707,14 +15716,13 @@ ports:
   tracking_issue: ''
   version: 0.6.4
 - current_min_cpp_version: Unknown
-  help_wanted: ❌
+  help_wanted: ❔
   homepage: https://github.com/microsoft/proxy
-  import_statement: proxy
-  modules_support_date: 2025/05/17
+  modules_support_date: ''
   name: proxy
   revision_count: 9
-  status: ✅
-  tracking_issue: https://github.com/microsoft/proxy/pull/293
+  status: ❔
+  tracking_issue: ''
   version: 2.3.2
 - current_min_cpp_version: Unknown
   help_wanted: ❔
@@ -18053,8 +18061,8 @@ ports:
   modules_support_date: ''
   name: sfml
   revision_count: 27
-  status: ❔
-  tracking_issue: ''
+  status: ⚙️
+  tracking_issue: https://github.com/SFML/SFML/pull/3467
   version: 2.6.1
 - current_min_cpp_version: Unknown
   help_wanted: ❔
@@ -21827,15 +21835,6 @@ ports:
   version: 0.13.73
 - current_min_cpp_version: Unknown
   help_wanted: ❔
-  homepage: https://www.dealii.org
-  modules_support_date: ''
-  name: deal.II
-  revision_count: 1
-  status: ⚙️
-  tracking_issue: https://github.com/dealii/dealii/issues/18071
-  version: 9.6.2
-- current_min_cpp_version: Unknown
-  help_wanted: ❔
   homepage: https://github.com/infiniflow/infinity
   import_statement: ''
   module_native: ✅
@@ -21944,3 +21943,13 @@ ports:
   status: ✅
   tracking_issue: ''
   version: ''
+- current_min_cpp_version: Unknown
+  help_wanted: ❔
+  homepage: https://www.dealii.org
+  import_statement: ''
+  module_native: ''
+  modules_support_date: ""
+  name: deal.II
+  status: ⚙️
+  tracking_issue: https://github.com/dealii/dealii/issues/18071
+  version: 9.6.2

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -143,7 +143,7 @@ ports:
   current_min_cpp_version: 20
   tracking_issue: "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/issues/29"
 - name: boost-pfr
-  import_statement: Boost.PFR
+  import_statement: boost.pfr
   modules_support_date: 2024/08/01
   status: ✅
   tracking_issue: "https://github.com/boostorg/pfr/pull/177"

--- a/data/progress_overwrite.yml
+++ b/data/progress_overwrite.yml
@@ -193,12 +193,6 @@ ports:
   status: ✅
   help_wanted: ❌
   tracking_issue: https://github.com/apolukhin/type_index/pull/15
-- name: nlohmann-json
-  import_statement: json
-  modules_support_date: 2025/05/01
-  status: ✅
-  help_wanted: ❌
-  tracking_issue: https://github.com/nlohmann/json/pull/4764
 - name: proxy
   import_statement: proxy
   modules_support_date: 2025/05/17
@@ -259,6 +253,11 @@ ports:
 - name: ClosureOS
   homepage: https://github.com/arttnba3/ClosureOS
   modules_support_date: 2025/5/15
+  status: ✅
+  module_native: ✅
+- name: openJuice
+  homepage: https://github.com/mikomikotaishi/openJuice
+  modules_support_date: 2024/8/7
   status: ✅
   module_native: ✅
 - name: lotus-engine


### PR DESCRIPTION
This pull request adds one of my modules projects to the examples page, and updates the `progress.yml` file with the libraries with current modules development in progress. Also, `<nlohmann/json.hpp>` does not have module support, only a CI test (one that I will probably try writing a module for later nonetheless)