### PR TITLE
CSS: Rotate the first three headers to make the columns narrower

### DIFF
--- a/layouts/partials/progress-module.html
+++ b/layouts/partials/progress-module.html
@@ -276,6 +276,16 @@
                 color: var(--input-text-color);
             }
 
+            th.rotated {
+                max-width: 2em;
+                white-space: nowrap;
+                text-overflow: visible;
+            }
+
+            th.rotated > div {
+                transform: rotate(340deg);
+            }
+
             .truncate-text-name {
                 max-width: 290px;
                 white-space: nowrap;
@@ -302,10 +312,10 @@
         </style>
         <thead>
             <tr style="text-align: left;">
-                <th>Status</th>
-                <th>Modules Native</th>
-                <th>Help<br>Wanted</th>
-                <th>Name</th>
+                <th class="rotated"><div>Status</div></th>
+                <th class="rotated"><div><br>Modules Native?</div></th>
+                <th class="rotated"><div><br><br>Help Wanted?</div></th>
+                <th>&emsp; Name</th>
                 <th>Import Statement</th>
                 <th>Popularity</th>
                 <th>Version</th>


### PR DESCRIPTION
Note to prospective merger: You probably want to take a look at this locally before you merge it. It's not the greatest design, and I'm not even 100% sure it renders well on devices that aren't my laptop (e.g. mobile). But it might be a first step toward something nicer.

The intent here is to rotate the first three `<th>`s, along the lines of https://css-tricks.com/rotated-table-column-headers/ , so that the one-emoji columns don't need to waste so much of the horizontal space.

A boring-technology alternative approach would be to change the `<th>` elements to just say `St`, `MN`, and `HW`; and then expand those initialisms in the legend already displayed above the table: `St: Status. ✅ Full support, etc.`, `MN: Modules Native. [...]`, `HW: Help Wanted? ✅ Yes ❌ No, etc.` That would also achieve the goal of not wasting so much horizontal space on columns that contain only a single emoji.