### PR TITLE
Adds sebsjames/maths

### DIFF
--- a/data/vcpkg_overrides.yml
+++ b/data/vcpkg_overrides.yml
@@ -282,7 +282,7 @@ ports:
   status: ✅
   tracking_issue: https://github.com/stripe2933/imgui-module
 - name: sebsjames-maths
-  import_statement: sm.mat, sm.vec, sm.vvec, sm.quaternion, sm.constexpr_math,...
+  import_statement: sm.*
   modules_support_date: 2026/3/27
   status: ✅
   tracking_issue: https://github.com/sebsjames/maths

--- a/data/vcpkg_overrides.yml
+++ b/data/vcpkg_overrides.yml
@@ -281,6 +281,13 @@ ports:
   modules_support_date: 2025/8/7
   status: ✅
   tracking_issue: https://github.com/stripe2933/imgui-module
+- name: sebsjames-maths
+  import_statement: sm.mat, sm.vec, sm.vvec, sm.quaternion, sm.constexpr_math,...
+  modules_support_date: 2026/3/27
+  status: ✅
+  tracking_issue: https://github.com/sebsjames/maths
+- homepage: https://sebsjames.github.io/maths/
+  modules_native: ✅
 - name: sqlpp23
   import_statement: sqlpp23.*
   modules_support_date: 2025/6/29


### PR DESCRIPTION
I've converted my C++20 maths library over to be pure modules. You have to `import` the maths code, you can't `#include` the code as headers. I think that makes the code 'modules-native', but internally, it still `#includes` standard library headers, rather than using C++23 `import std;` or `import <header>;`.

This library can do some of the things that Armadillo, Eigen and OpenGL maths (GLM) can do, and does so in a modern C++ style.

Please evaluate whether it would make a good addition to the examples page.