### PR TITLE
Update sccache modules support

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -33,7 +33,8 @@
 | GNU Autotools | ❌            | ❌            | ❌           |      |
 | Scons         | ⚙️            | ❌            | ❌           | [PR for GCC support](https://github.com/SCons/scons/pull/4248) |
 | ccache        | ⚙️            | ❌            | ❌           | [PR](https://github.com/ccache/ccache/pull/1523) |
-| sccache       | ⚙️            | ❌            | ❌           | [PR (clang)](https://github.com/mozilla/sccache/pull/2516) |
+| sccache (clang) | ✅          | ✅            | ❌           |      |
+| sccache (gcc/MSVC) | ❌       | ❌            | ❌           |      |
 | Bazel         | ✅            | ⚙️            | ❌           | [Issue Link](https://github.com/bazelbuild/bazel/issues/4005) |
 | Gradle        | ❌            | ❌            | ❌           | [Issue Link](https://github.com/gradle/gradle/issues/29009) |
 | fastbuild     | ❌            | ❌            | ❌           | [Issue Link](https://github.com/fastbuild/fastbuild/issues/1026) |


### PR DESCRIPTION
sccache gained support for modules with clang in v0.15.0.

Because they are not yet supported with gcc/MSVC, I split the entry into two.