### PR TITLE
Correct the module name used by cppwinrt

### DIFF
--- a/data/vcpkg_overrides.yml
+++ b/data/vcpkg_overrides.yml
@@ -358,7 +358,7 @@ ports:
   tracking_issue: https://github.com/boostorg/lexical_cast/pull/96
 - name: cppwinrt
   status: ✅
-  import_statement: winrt
+  import_statement: winrt.*
   modules_support_date: 2026-05-20
   homepage: https://github.com/microsoft/cppwinrt
   tracking_issue: https://github.com/microsoft/cppwinrt/pull/1575


### PR DESCRIPTION
cppwinrt once attempted to use a single winrt module, but it never reached a usable state. Over the past few months, I reimplemented it together with the maintainer, and at my strong insistence, it was implemented as one module per namespace, see https://github.com/microsoft/cppwinrt/pull/1575.