### PR TITLE
Update the status of CMake for `import std;`

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -21,7 +21,7 @@
 |---------------|---------------|---------------|--------------|------|
 | Ninja         | ✅ 1.11       | ✅ 1.11       | ❌           |      |
 | MSBuild       | ✅            | ✅            | ❌           |      |
-| CMake         | ✅ 3.28       | ⚙️ 3.30       | ❌           | Support for `import std;` is experimental ([blog post](https://www.kitware.com/import-std-in-cmake-3-30/)). |
+| CMake         | ✅ 3.28       | ✅ 4.3       | ❌           |      |
 | XMake         | ✅            | ✅            | ✅           | [Release](https://github.com/xmake-io/xmake/wiki/Xmake-v2.7.1-Released,-Better-Cplusplus-Modules-Support) |
 | Zork++        | ✅            | ✅            | ❌           | [Project](https://github.com/zerodaycode/Zork) |
 | Build2        | ✅            | ✅ 0.17.0     | ❌           | [Issue Link](https://github.com/build2/build2/issues/333) |


### PR DESCRIPTION
Starting with CMake 4.3, `CMAKE_MODULE_STD` is no longer experimental. See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11657 .